### PR TITLE
Namespace and Folder corrections

### DIFF
--- a/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Api/MSC.WhittierArtists.Api.csproj
+++ b/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Api/MSC.WhittierArtists.Api.csproj
@@ -23,4 +23,10 @@
     <ProjectReference Include="..\$ext_safeprojectname$.Shared\$ext_safeprojectname$.Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Authorization\" />
+    <Folder Include="Models\" />
+    <Folder Include="Services\" />
+  </ItemGroup>
+
 </Project>

--- a/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Repository/MSC.WhittierArtists.Repository.csproj
+++ b/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Repository/MSC.WhittierArtists.Repository.csproj
@@ -16,4 +16,10 @@
     <ProjectReference Include="..\$ext_safeprojectname$.Shared\$ext_safeprojectname$.Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Entities\" />
+    <Folder Include="Mappers\" />
+    <Folder Include="Repositories\" />
+  </ItemGroup>
+
 </Project>

--- a/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Shared/DTO/CGHAppSettings.cs
+++ b/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Shared/DTO/CGHAppSettings.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-namespace CodeGenHeroBlazor6.Shared.DTO
+namespace $safeprojectname$.DTO
 {
     public class CGHAppSettings
     {


### PR DESCRIPTION
Corrected the template for CFHAppSettings to match the provided Solution name instead of "CGHBlazor6.Shared", and edited the Project .csproject templates to Include empty folders intended to hold generated classes so that end-users do not need to themselves.