### PR TITLE
IQueryableExtensions contains-filter expansion

### DIFF
--- a/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Repository/Infrastructure/IQueryableExtensions.cs
+++ b/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Repository/Infrastructure/IQueryableExtensions.cs
@@ -34,19 +34,33 @@ namespace $safeprojectname$.Infrastructure
                 condition = (format, member) => string.Format(format, member); // System.Linq.Dynamic Object:  {PropertyName}{condition}
 
             object typedFilterValue = filter.Value;
+            
             if (isDateTime)
-                typedFilterValue = DateTime.Parse(filter.Value);
+            {
+                if (DateTime.TryParse(filter.Value, result: out var parseOutput))
+                    typedFilterValue = parseOutput;
+            }
             else if (isGuid)
-                typedFilterValue = Guid.Parse(filter.Value);
+            {
+                if (Guid.TryParse(filter.Value, result: out var parseOutput))
+                    typedFilterValue = parseOutput;
+            }
             else if (isBoolean)
-                typedFilterValue = Boolean.Parse(filter.Value);
+            {
+                if (bool.TryParse(filter.Value, result: out var parseOutput))
+                    typedFilterValue = parseOutput;
+            }
             else if (isShort)
-                typedFilterValue = Int16.Parse(filter.Value);
+            {
+                if (Int16.TryParse(filter.Value, result: out var parseOutput))
+                    typedFilterValue = parseOutput;
+            }
             else if (isInt)
             {
                 if (!isFilterAnArray)
                 {
-                    typedFilterValue = Int32.Parse(filter.Value);
+                    if (Int32.TryParse(filter.Value, result: out var parseOutput))
+                        typedFilterValue = parseOutput;
                 }
             }
 

--- a/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Shared/Constants/Enums.cs
+++ b/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Shared/Constants/Enums.cs
@@ -8,6 +8,8 @@ namespace $safeprojectname$.Constants
         {
             Contains,
             DoesNotContain,
+            IsContainedIn,
+            IsNotContainedIn,
             IsGreaterThan,
             IsGreaterThanOrEqual,
             IsLessThan,

--- a/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Shared/Extensions/ObjectExtensions.cs
+++ b/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Shared/Extensions/ObjectExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace $safeprojectname$.Extensions
+{
+    public static class ObjectExtensions
+    {
+        // Based off of https://stackoverflow.com/questions/3502493/is-there-any-generic-parse-function-that-will-convert-a-string-to-any-type-usi
+        public static T ConvertTo<T>(this object value)
+        {
+            if (value is T variable) return variable;
+
+            try
+            {
+                // Handling Nullable types i.e, int?, double?, bool? .. etc
+                if (Nullable.GetUnderlyingType(typeof(T)) != null || typeof(T).FullName.Contains("System.Guid"))
+                {
+                    return (T)TypeDescriptor.GetConverter(typeof(T)).ConvertFrom(value);
+                }
+
+                return (T)Convert.ChangeType(value, typeof(T));
+            }
+            catch (Exception)
+            {
+                return default(T);
+            }
+        }
+    }
+}

--- a/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Shared/Extensions/ObjectExtensions.cs
+++ b/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Shared/Extensions/ObjectExtensions.cs
@@ -20,9 +20,9 @@ namespace $safeprojectname$.Extensions
 
                 return (T)Convert.ChangeType(value, typeof(T));
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                return default(T);
+                throw ex; // "Does this mask an error when it shouldn't? Would it be best to let this fail?"
             }
         }
     }


### PR DESCRIPTION
Expands the IQueryableExtensions with new IsContainedIn, and IsNotContainedIn criterion conditions for handling List based filtering in a Generic manner, as well as the addition of ObjectExtensions ConvertTo<T>() as a form of a Generic Parse.