### PR TITLE
Bug/220502 template errors

### DIFF
--- a/src/net6/CGH Bundle/CodeGenHero.Template.Blazor6.csproj
+++ b/src/net6/CGH Bundle/CodeGenHero.Template.Blazor6.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="CodeGenHero.Core" Version="1.3.2" />
     <PackageReference Include="CodeGenHero.Inflector" Version="1.0.7" />
-    <PackageReference Include="CodeGenHero.Template" Version="1.3.9" />
+    <PackageReference Include="CodeGenHero.Template" Version="1.4.1" />
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/src/net6/CGH Bundle/Consts.cs
+++ b/src/net6/CGH Bundle/Consts.cs
@@ -21,7 +21,7 @@
         public const string BlazorRepositoryDbContextClassName_DEFAULTDESCRIPTION = "The name of the DbContext class for your Metadata.";
         public const string BlazorRepositoryDbContextClassName_DEFAULTVALUE = "{BaseNamespace}DbContext";
         public const string BlazorRepositoryEntitiesNamespace_DEFAULTDESCRIPTION = "The namespace of the DBContext and Entity Model classes.";
-        public const string BlazorRepositoryEntitiesNamespace_DEFAULTVALUE = "{BaseNamespace}.Entities";
+        public const string BlazorRepositoryEntitiesNamespace_DEFAULTVALUE = "{BaseNamespace}.Repository.Entities";
         public const string Entities_Namespace_DEFAULTVALUE = "{baseNamespace}.DataAccess.Entities.{namespacePostfix}";
         public const string Model_Namespace_DEFAULTVALUE = "{baseNamespace}.Model";
 

--- a/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Shared/BlazorShared.vstemplate
+++ b/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Shared/BlazorShared.vstemplate
@@ -52,6 +52,7 @@
         <ProjectItem ReplaceParameters="true" TargetFileName="EnumerableExtensions.cs">EnumerableExtensions.cs</ProjectItem>
         <ProjectItem ReplaceParameters="true" TargetFileName="FunctorComparer.cs">FunctorComparer.cs</ProjectItem>
         <ProjectItem ReplaceParameters="true" TargetFileName="IListExtensions.cs">IListExtensions.cs</ProjectItem>
+        <ProjectItem ReplaceParameters="true" TargetFileName="ObjectExtensions.cs">ObjectExtensions.cs</ProjectItem>
       </Folder>
       <ProjectItem ReplaceParameters="true" TargetFileName="AsyncHelper.cs">AsyncHelper.cs</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="Utils.cs">Utils.cs</ProjectItem>

--- a/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.IDP/MSC.IDP.csproj
+++ b/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.IDP/MSC.IDP.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <UserSecretsId>0F1064CC-A830-41AA-9216-FD57931D83B1</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ReadMe.md
+++ b/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ReadMe.md
@@ -12,7 +12,7 @@
 
 - Transfer (Cut / Paste) the connection string value from appsettings.json into the secrets.json file. Note that the format of the key gets collapsed in the secrets.json file to "ConnectionStrings:UserDbContextConnection": "\<your connection string\>" instead of the way it is nested in the appsettings.json file.
 
-- Repeat the above process for the Api project to transfer the "ConnectionStrings:DefaultConnection" value from appsettings.jon to the secrets.json file for the Api project.
+- Repeat the above process for the Api project to transfer the "ConnectionStrings:DefaultConnection" value from appsettings.json to the secrets.json file for the Api project.
 
 2.	Right-click on the solution in Solution Explorer and select Properties.
 - The multiple startup projects option should be selected and the action should be set to start for the Api, Client, and IDP projects.
@@ -20,7 +20,7 @@
 3.	Try running / debugging the solution
 - Did all three projects start up (IdentityServer4, Your Blazor App (Blazor Wasm), and the Api project?
 - Look at the console window for the running Api project. What port is it listening on - 5301 (note that it may also be listening on 5302 for gRPC calls)?
-- Navigate to the port the API project is running on [https://localhost:5301/](https://localhost:5301/) and you should see the  assembly version displayed as "Version 1.0.0".
+- Navigate to the port the API project is running on [https://localhost:5301/](https://localhost:5301/) and you should see the assembly version displayed as "Version 1.0.0".
 - Navigate to the Swagger page [https://localhost:5301/swagger/index.html](https://localhost:5301/swagger/index.html)
 - Click the **GET** button for the "/api/TestAuth/TestAdmin" function to expand it, then click the **Try it out** button, then click the **Execute** button. You should see a "Error: response status is 401" message indicating you are not authorized.
 - Click the **Authorize** button at the top right of Swagger's index page. Notice that it wants a JWT Bearer token. Next, we will use Postman to get that Bearer token.


### PR DESCRIPTION
Corrected flaws in the Multi-Project Template:

- Removed Secrets Guid from IDP project so that new projects will generate their own Secrets rather than overlap
- Corrected errors in Readme.Md
- Corrected default BlazorRepositoryEntitiesNamespace template variable value to be "{BaseNamespace}_.Repository_.Entities"
- Updated CodeGenHero.Template NuGet package reference to latest version (See https://github.com/MSCTek/CodeGenHero/pull/10)