### PR TITLE
Default Client Project to Development configuration

### DIFF
--- a/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Wizard/RootWizard.cs
+++ b/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Wizard/RootWizard.cs
@@ -127,9 +127,14 @@ namespace CodeGenHero.ProjectTemplate.Blazor6.Wizard
 
                 if (clientProject != null)
                 {
-                    // Would have preferred to LINQ this, but it seems that these classes don't seem to be LINQable.
+                    bool isFinished = false;
+
+                    // Would have preferred to LINQ this, but it seems that these classes don't seem to be LINQable. // solutionConfiguration.Name == "Debug"
                     foreach (SolutionConfiguration solutionConfiguration in _dte2.Solution.SolutionBuild.SolutionConfigurations)
                     {
+                        if (solutionConfiguration.Name != "Debug")
+                            continue;
+
                         foreach (SolutionContext solutionContext in solutionConfiguration.SolutionContexts)
                         {
                             if (solutionContext.ProjectName.IndexOf(clientProject.Name) > -1)
@@ -138,8 +143,13 @@ namespace CodeGenHero.ProjectTemplate.Blazor6.Wizard
                                 // https://stackoverflow.com/questions/17029011/fixing-configuration-platform-in-envdte-for-added-project
                                 // https://stackoverflow.com/questions/9792278/visualstudio-multi-project-templates
                                 solutionContext.ConfigurationName = "Development|Any CPU";
+                                isFinished = true;
+                                break;
                             }
                         }
+
+                        if (isFinished)
+                            break;
                     }
                 }
             }

--- a/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Wizard/RootWizard.cs
+++ b/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Wizard/RootWizard.cs
@@ -122,6 +122,26 @@ namespace CodeGenHero.ProjectTemplate.Blazor6.Wizard
                 {
                     _dte2.Solution.SolutionBuild.StartupProjects = startupProjects.ToArray();
                 }
+
+                var clientProject = GetProject(".Client", solutionProjects);
+
+                if (clientProject != null)
+                {
+                    // Would have preferred to LINQ this, but it seems that these classes don't seem to be LINQable.
+                    foreach (SolutionConfiguration solutionConfiguration in _dte2.Solution.SolutionBuild.SolutionConfigurations)
+                    {
+                        foreach (SolutionContext solutionContext in solutionConfiguration.SolutionContexts)
+                        {
+                            if (solutionContext.ProjectName.IndexOf(clientProject.Name) > -1)
+                            {
+                                // Default the Client Project to "Development" configuration so IdentityServer will cooperate with it.
+                                // https://stackoverflow.com/questions/17029011/fixing-configuration-platform-in-envdte-for-added-project
+                                // https://stackoverflow.com/questions/9792278/visualstudio-multi-project-templates
+                                solutionContext.ConfigurationName = "Development|Any CPU";
+                            }
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
- Added logic to RootWizard to default the Client project to the Development configuration so that it can work with IdentityServer out of the box.