### PR TITLE
API Controller SourceChanged Fix

### DIFF
--- a/src/net6/CGH Bundle/Consts.cs
+++ b/src/net6/CGH Bundle/Consts.cs
@@ -116,7 +116,7 @@
         /// Output Filepath Defaults
         public const string APIControllerFilePath_DEFAULTVALUE = "Blazor\\Controllers\\[tablename]Controller.cs";
 
-        public const string APIControllerCustomFilepath_DEFAULTVALUE = "Blazor\\Controllers\\Custom\\[tablename]Controller.cs";
+        public const string APIControllerCustomFilepath_DEFAULTVALUE = "Blazor\\Controllers\\Custom\\[tablename]ControllerCustom.cs";
 
         public const string AutoMapperProfileOutputFilepath_DEFAULT = "Blazor\\Repository\\{NamespacePostfix}AutoMapperProfile.cs";
 


### PR DESCRIPTION
Fixed typo causing APIControllerCustom to have the same default filename as APIController, resulting in Custom attempting to overwrite the regular API Controller class.