### PR TITLE
WebApiDataService: Treat getting HTTP Client as Method, rather than Property

### DIFF
--- a/src/net6/AAD VSIX/CGHTemplate.BlazorAAD.Deploy/ProjectTemplates/CGHBlazorAAD/CGHBlazorAAD.Client/Program.cs
+++ b/src/net6/AAD VSIX/CGHTemplate.BlazorAAD.Deploy/ProjectTemplates/CGHBlazorAAD/CGHBlazorAAD.Client/Program.cs
@@ -23,7 +23,7 @@ Console.WriteLine($"apiBaseAddress: {apiBaseAddress}");
 
 builder.Services.AddScoped<CustomAuthorizationMessageHandler>();
 
-builder.Services.AddHttpClient("CGHApi",
+builder.Services.AddHttpClient(Consts.HTTPCLIENTNAME_AUTHORIZED,
     client =>
     {
         client.BaseAddress = new Uri(apiBaseAddress);
@@ -31,7 +31,7 @@ builder.Services.AddHttpClient("CGHApi",
     })
     .AddHttpMessageHandler<CustomAuthorizationMessageHandler>();
 
-builder.Services.AddHttpClient("CGHApiAnonymous",
+builder.Services.AddHttpClient(Consts.HTTPCLIENTNAME_ANONYMOUS,
     client =>
     {
         client.BaseAddress = new Uri(apiBaseAddress);

--- a/src/net6/AAD VSIX/CGHTemplate.BlazorAAD.Deploy/ProjectTemplates/CGHBlazorAAD/CGHBlazorAAD.Client/Services/IWebApiDataServiceBase.cs
+++ b/src/net6/AAD VSIX/CGHTemplate.BlazorAAD.Deploy/ProjectTemplates/CGHBlazorAAD/CGHBlazorAAD.Client/Services/IWebApiDataServiceBase.cs
@@ -6,8 +6,6 @@ namespace $safeprojectname$.Services
 
     public partial interface IWebApiDataServiceBase
     {
-        HttpClient HttpClient { get; }
-
         string IsServiceOnlineRelativeUrl { get; set; }
 
         ILogger Log { get; set; }

--- a/src/net6/AAD VSIX/CGHTemplate.BlazorAAD.Deploy/ProjectTemplates/CGHBlazorAAD/CGHBlazorAAD.Shared/Constants/Consts.cs
+++ b/src/net6/AAD VSIX/CGHTemplate.BlazorAAD.Deploy/ProjectTemplates/CGHBlazorAAD/CGHBlazorAAD.Shared/Constants/Consts.cs
@@ -35,7 +35,8 @@
         public const string AAD_GROUP_CONFIGURATION = "AADGroupConfiguration";
         public const string ACCESS_ADMIN = "Admin";
         public const string ACCESS_USER = "HasUserAccess";
-        public const string ACCESS_TRAP_RESULTS_SEARCH = "HasTrapResultsSearchAccess";
-        public const string ACCESS_TRAP_INFORMATION = "HasTrapInformationAccess";
+
+        public const string HTTPCLIENTNAME_AUTHORIZED = "CGHApi";
+        public const string HTTPCLIENTNAME_ANONYMOUS = "CGHApiAnonymous";
     }
 }

--- a/src/net6/CGH Bundle/Generators/WebApiDataServiceGenerator.cs
+++ b/src/net6/CGH Bundle/Generators/WebApiDataServiceGenerator.cs
@@ -52,10 +52,10 @@ namespace CodeGenHero.Template.Blazor6.Generators
             sb.AppendLine($"public {className}(ILogger<{className}> logger,");
             sb.AppendLine("\tIHttpClientFactory httpClientFactory,");
             sb.AppendLine("\tISerializationHelper serializationHelper,");
-            sb.AppendLine("\tAuthenticationStateProvider authenticationStateProvider)")
+            sb.AppendLine("\tAuthenticationStateProvider authenticationStateProvider)");
             sb.AppendLine("\t: base(logger, serializationHelper, httpClientFactory,");
             sb.AppendLine($"\t\tisServiceOnlineRelativeUrl: \"{apiUrl}/{namespacePostfix}ApiStatus\",");
-            sb.AppendLine("\t\tauthenticationStateProvider: authenticationStateProvider)")
+            sb.AppendLine("\t\tauthenticationStateProvider: authenticationStateProvider)");
             sb.AppendLine("{");
             sb.AppendLine("}");
 
@@ -188,7 +188,7 @@ namespace CodeGenHero.Template.Blazor6.Generators
 
             sb.AppendLine($"\tstring requestUrl = $\"{apiUrl}/{entityName}/{{(int)pageDataRequest.RelatedEntitiesType}}/\";");
             sb.AppendLine($"\tvar retVal = await SerializationHelper.SerializeCallResultsGet<IList<xDTO.{entityName}>>(");
-            sb.AppendLine("\t\tLog, HttpClient, requestUrl,");
+            sb.AppendLine("\t\tLog, await GetHttpClientAsync(), requestUrl,");
             sb.AppendLine("\t\tfilter: filter,");
             sb.AppendLine("\t\tsort: pageDataRequest.Sort,");
             sb.AppendLine("\t\tpage: pageDataRequest.Page,");
@@ -276,7 +276,7 @@ namespace CodeGenHero.Template.Blazor6.Generators
                 sb.AppendLine($"\t{fieldSignature}, Enums.RelatedEntitiesType relatedEntitiesType)");
                 sb.AppendLine("{");
 
-                sb.AppendLine($"\tvar retVal = await SerializationHelper.SerializeCallResultsGet<xDTO.{entityName}>(Log, HttpClient,");
+                sb.AppendLine($"\tvar retVal = await SerializationHelper.SerializeCallResultsGet<xDTO.{entityName}>(Log, await GetHttpClientAsync(),");
                 sb.AppendLine($"\t\t$\"{apiUrl}/{entityName}/ById/{{{signature}}}/{{(int)relatedEntitiesType}}\");");
                 sb.AppendLine("\treturn retVal;");
 
@@ -305,7 +305,7 @@ namespace CodeGenHero.Template.Blazor6.Generators
                 sb.AppendLine("{");
 
                 sb.AppendLine($"\tvar retVal = await SerializationHelper.SerializeCallResultsPost<xDTO.{entityName}>(");
-                sb.AppendLine("\t\tLog, HttpClient,");
+                sb.AppendLine("\t\tLog, await GetHttpClientAsync(),");
                 sb.AppendLine($"\t\t$\"{apiUrl}/{entityName}/\", item);");
                 sb.AppendLine("\treturn retVal;");
 
@@ -335,7 +335,7 @@ namespace CodeGenHero.Template.Blazor6.Generators
                 sb.AppendLine("{");
                 
                 sb.AppendLine($"\tvar retVal = await SerializationHelper.SerializeCallResultsPut<xDTO.{entityName}>(");
-                sb.AppendLine("\t\tLog, HttpClient,");
+                sb.AppendLine("\t\tLog, await GetHttpClientAsync(),");
                 sb.Append($"\t\t\t\t$\"{apiUrl}/{entityName}");
                 foreach (var key in primaryKeys)
                 {
@@ -372,7 +372,7 @@ namespace CodeGenHero.Template.Blazor6.Generators
                 sb.AppendLine("{");
 
                 sb.AppendLine($"\tvar retVal = await SerializationHelper.SerializeCallResultsDelete<xDTO.{entityName}>(");
-                sb.AppendLine("\t\tLog, HttpClient,");
+                sb.AppendLine("\t\tLog, await GetHttpClientAsync(),");
                 sb.AppendLine($"\t\t\t\t$\"{apiUrl}/{entityName}/{{{apiSignature}}}\");");
                 sb.AppendLine(string.Empty);
 

--- a/src/net6/CGH Bundle/Templates/WebApiDataServiceTemplate.cs
+++ b/src/net6/CGH Bundle/Templates/WebApiDataServiceTemplate.cs
@@ -16,6 +16,9 @@ namespace CodeGenHero.Template.Blazor6.Templates
 
         #region TemplateVariables
 
+        [TemplateVariable(defaultValue: Consts.PTG_ApplicationProjectName_DEFAULT, description: Consts.PTG_ApplicationProjectName_DESC)]
+        public string ApplicationProjectName { get; set; }
+
         [TemplateVariable(defaultValue: Consts.PTG_WebApiDataServiceNamespace_DEFAULT, description: Consts.PTG_WebApiDataServiceNamespace_DESC)]
         public string WebApiDataServiceNamespace { get; set; }
 
@@ -56,6 +59,7 @@ namespace CodeGenHero.Template.Blazor6.Templates
                     new NamespaceItem("System.Net.Http"),
                     new NamespaceItem("System.Threading.Tasks"),
                     //new NamespaceItem("System.Text.Json")
+                    new NamespaceItem("Microsoft.AspNetCore.Components.Authorization"),
                     new NamespaceItem("Microsoft.Extensions.Logging"),
                     new NamespaceItem($"{BaseNamespace}.Shared.DataService"),
                     new NamespaceItem($"Enums = {BaseNamespace}.Shared.Constants.Enums"),

--- a/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.App/Services/IWebApiDataServiceBase.cs
+++ b/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.App/Services/IWebApiDataServiceBase.cs
@@ -6,8 +6,6 @@ namespace $safeprojectname$.Services
 {
     public partial interface IWebApiDataServiceBase
     {
-        HttpClient HttpClient { get; }
-
         string IsServiceOnlineRelativeUrl { get; set; }
 
         ILogger Log { get; set; }

--- a/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Client/Program.cs
+++ b/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Client/Program.cs
@@ -2,6 +2,7 @@ using $ext_safeprojectname$.App.MessageHandlers;
 using $ext_safeprojectname$.App.Services;
 using $ext_safeprojectname$.Client.Services;
 using $ext_safeprojectname$.Shared.Authorization;
+using $ext_safeprojectname$.Shared.Constants;
 using $ext_safeprojectname$.Shared.DataService;
 using $ext_safeprojectname$.Shared.DTO;
 using Majorsoft.Blazor.Components.GdprConsent;
@@ -64,7 +65,7 @@ namespace $safeprojectname$
             var apiBaseAddress = CGHAppSettingsSection["ApiBaseAddress"];
             Console.WriteLine($"apiBaseAddress: {apiBaseAddress}");
 
-            builder.Services.AddHttpClient("CGHApi", c =>
+            builder.Services.AddHttpClient(Consts.HTTPCLIENTNAME_AUTHORIZED, c =>
             {
                 c.BaseAddress = new Uri(apiBaseAddress);
                 c.DefaultRequestHeaders.Add("api-version", "1");

--- a/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Server/Startup.cs
+++ b/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Server/Startup.cs
@@ -85,7 +85,7 @@ namespace $safeprojectname$
             var apiBaseAddress = cghAppSettingsSection[nameof(CGHAppSettings.ApiBaseAddress)];
             Console.WriteLine($"apiBaseAddress: {apiBaseAddress}");
 
-            services.AddHttpClient("CGHApi", c =>
+            services.AddHttpClient(Consts.HTTPCLIENTNAME_AUTHORIZED, c =>
             {
                 c.BaseAddress = new Uri(apiBaseAddress);
                 c.DefaultRequestHeaders.Add("api-version", "1");

--- a/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Shared/Constants/Consts.cs
+++ b/src/net6/VS VSIX/MSC.CGH.BlazorTemplate.Deploy/ProjectTemplates/MSC.BlazorTemplate/MSC.BlazorTemplate.Shared/Constants/Consts.cs
@@ -31,5 +31,8 @@
         public const string OPERATOR_STARTSWITH = "StartsWith";
 
         #endregion CGH
+
+        public const string HTTPCLIENTNAME_AUTHORIZED = "CGHApi";
+        public const string HTTPCLIENTNAME_ANONYMOUS = "CGHApiAnonymous";
     }
 }


### PR DESCRIPTION
Changed Getter for HTTP Client to a Method rather than Property for better thread-safety, changed HTTP Client names to Consts, added additional Using Statements and Configuration values to WebApiDataService template, removed redundant Const values