### PR TITLE
Admin Page Templates: Parameterized authorized roles

### DIFF
--- a/src/net6/CGH Bundle/Consts.cs
+++ b/src/net6/CGH Bundle/Consts.cs
@@ -196,6 +196,9 @@
 
         #endregion
 
+        public const string PTG_AdminPageAuthorizedRoles_DEFAULT = "Consts.ROLE_ADMIN_OR_USER";
+        public const string PTG_AdminPageAuthorizedRoles_DESC = "Comma-delimited roles authorized to access generated Admin pages, based off roles established in your Identity Provider. Should be promoted to Global.";
+
         /// Class-specific variables
         // Web API Data Service
         public const string WebApiDataServiceCheckForIsActiveRegex = "Regular Expression to determine which Entities should have an \"IsActive\" check in their Get Methods. Only include entities that have a boolean property of this name.";

--- a/src/net6/CGH Bundle/Generators/AdminEditViewModelGenerator.cs
+++ b/src/net6/CGH Bundle/Generators/AdminEditViewModelGenerator.cs
@@ -21,6 +21,7 @@ namespace CodeGenHero.Template.Blazor6.Generators
             string namespacePostfix,
             IEntityType entity,
             string className,
+            string adminPageAuthorizedRoles,
             string webApiDataServiceInterfaceClassName,
             string webApiDataServiceClassName)
         {
@@ -28,7 +29,14 @@ namespace CodeGenHero.Template.Blazor6.Generators
 
             sb.Append(GenerateHeader(usings, classNamespace));
 
-            sb.AppendLine("\t[Authorize(Roles = Consts.ROLE_ADMIN_OR_USER)]");
+            if (!string.IsNullOrEmpty(adminPageAuthorizedRoles))
+            {
+                sb.AppendLine($"\t[Authorize(Roles = {adminPageAuthorizedRoles})]");
+            }
+            else
+            {
+                sb.AppendLine("\t[Authorize]");
+            }
             sb.AppendLine($"\tpublic partial class {className} : AdminPageBase");
             sb.AppendLine("\t{");
 
@@ -197,19 +205,9 @@ namespace CodeGenHero.Template.Blazor6.Generators
             sb.AppendLine("\t\t\t\t{");
 
             sb.AppendLine($"\t\t\t\t\tvar {entityNameLower} = result.Data;");
-            sb.AppendLine("\t\t\t\t\t// Admins and other approved user claims (Add below) only");
-            sb.AppendLine("\t\t\t\t\tif (!User.IsInRole(Consts.ROLE_ADMIN))");
-            sb.AppendLine("\t\t\t\t\t{");
+            sb.AppendLine($"\t\t\t\t\t{entityName} = {entityNameLower};");
 
-            sb.AppendLine("\t\t\t\t\t\tNavigationManager.NavigateTo($\"/Authorization/AccessDenied\");");
-
-            sb.AppendLine("\t\t\t\t\t}");
-            sb.AppendLine("\t\t\t\t\telse");
-            sb.AppendLine("\t\t\t\t\t{");
-
-            sb.AppendLine($"\t\t\t\t\t\t{entityName} = {entityNameLower};");
-
-            sb.AppendLine("\t\t\t\t\t}");
+            // The "User.IsInRole" check redirect to "Access Denied" that was here is redundant with the use of the Authorize attribute at the top of the class.
 
             sb.AppendLine("\t\t\t\t}");
 

--- a/src/net6/CGH Bundle/Generators/AdminListPageViewModelGenerator.cs
+++ b/src/net6/CGH Bundle/Generators/AdminListPageViewModelGenerator.cs
@@ -20,6 +20,7 @@ namespace CodeGenHero.Template.Blazor6.Generators
             string namespacePostfix,
             IEntityType entity,
             string className,
+            string adminPageAuthorizedRoles,
             string webApiDataServiceInterfaceClassName,
             string webApiDataServiceClassName)
         {
@@ -33,7 +34,14 @@ namespace CodeGenHero.Template.Blazor6.Generators
 
             sb.Append(GenerateHeader(usings, classNamespace));
 
-            sb.AppendLine("\t[Authorize(Roles = Consts.ROLE_ADMIN_OR_USER)]");
+            if (!string.IsNullOrEmpty(adminPageAuthorizedRoles))
+            {
+                sb.AppendLine($"\t[Authorize(Roles = {adminPageAuthorizedRoles})]");
+            }
+            else
+            {
+                sb.AppendLine("\t[Authorize]");
+            }
             sb.AppendLine($"\tpublic partial class {className} : AdminPageBase");
             sb.AppendLine("\t{");
             sb.AppendLine($"\t\tpublic {className}()");

--- a/src/net6/CGH Bundle/Templates/AdminEditViewModelTemplate.cs
+++ b/src/net6/CGH Bundle/Templates/AdminEditViewModelTemplate.cs
@@ -34,6 +34,9 @@ namespace CodeGenHero.Template.Blazor6.Templates
         [TemplateVariable(defaultValue: Consts.PTG_DtoNamespace_DEFAULT, description: Consts.PTG_DtoNamespace_DESC)]
         public string DtoNamespace { get; set; }
 
+        [TemplateVariable(defaultValue: Consts.PTG_AdminPageAuthorizedRoles_DEFAULT, description: Consts.PTG_AdminPageAuthorizedRoles_DESC)]
+        public string AdminPageAuthorizedRoles { get; set; }
+
         [TemplateVariable(defaultValue: Consts.PTG_ApplicationProjectName_DEFAULT, description: Consts.PTG_ApplicationProjectName_DESC)]
         public string ApplicationProjectName { get; set; }
 
@@ -78,7 +81,7 @@ namespace CodeGenHero.Template.Blazor6.Templates
                     string className = TokenReplacements(AdminEditViewModelClassName, entity);
 
                     var generator = new AdminEditViewModelGenerator(inflector: Inflector);
-                    var generatedCode = generator.Generate(usings, AdminPageNamespace, NamespacePostfix, entity, className, WebApiDataServiceInterfaceClassName, WebApiDataServiceClassName);
+                    var generatedCode = generator.Generate(usings, AdminPageNamespace, NamespacePostfix, entity, className, AdminPageAuthorizedRoles, WebApiDataServiceInterfaceClassName, WebApiDataServiceClassName);
 
                     retVal.Files.Add(new OutputFile()
                     {

--- a/src/net6/CGH Bundle/Templates/AdminListPageViewModelTemplate.cs
+++ b/src/net6/CGH Bundle/Templates/AdminListPageViewModelTemplate.cs
@@ -35,6 +35,9 @@ namespace CodeGenHero.Template.Blazor6.Templates
         [TemplateVariable(defaultValue: Consts.PTG_AdminPageNamespace_DEFAULT, description: Consts.PTG_AdminPageNamespace_DESC)]
         public string AdminPageNamespace { get; set; }
 
+        [TemplateVariable(defaultValue: Consts.PTG_AdminPageAuthorizedRoles_DEFAULT, description: Consts.PTG_AdminPageAuthorizedRoles_DESC)]
+        public string AdminPageAuthorizedRoles { get; set; }
+
         [TemplateVariable(defaultValue: Consts.PTG_ApplicationProjectName_DEFAULT, description: Consts.PTG_ApplicationProjectName_DESC)]
         public string ApplicationProjectName { get; set; }
 
@@ -79,7 +82,7 @@ namespace CodeGenHero.Template.Blazor6.Templates
                     string className = TokenReplacements(AdminListPageViewModelClassName, entity);
 
                     var generator = new AdminListPageViewModelGenerator(inflector: Inflector);
-                    var generatedCode = generator.Generate(usings, AdminPageNamespace, NamespacePostfix, entity, className, WebApiDataServiceInterfaceClassName, WebApiDataServiceClassName);
+                    var generatedCode = generator.Generate(usings, AdminPageNamespace, NamespacePostfix, entity, className, AdminPageAuthorizedRoles, WebApiDataServiceInterfaceClassName, WebApiDataServiceClassName);
 
                     retVal.Files.Add(new OutputFile()
                     {


### PR DESCRIPTION
Alters the Authorize attribute on Admin Page templates to be based off a parameter-based role instead of being hardcoded to the template project Const Admin role. Removes redundant role-checks in the Admin Edit Page, as the Authorize attribute on the viewmodel should already have this authority.

If the provided role is blank/empty, will only check for Login with no role check.